### PR TITLE
added secrets management for cache endpoints

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10,9 +10,9 @@ import CronJobHandler from "./db/redisCronJobs.js";
 import 'dotenv/config';
 import cron from 'node-cron';
 import cors from 'cors';
-const PORT = 3003;
+const PORT = process.env.ENV_PORT || 3003;
 const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
-const redisEndpoints = ['micro-redis.xjdmww.clustercfg.usw1.cache.amazonaws.com:6379']; //remove this from source code
+const redisEndpoints = [process.env.CACHE_ENDPOINT || 'redis://localhost:6379'];
 const corsOptions = {
     origin: true,
     credentials: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,9 @@ import 'dotenv/config';
 import cron from 'node-cron';
 import cors from 'cors';
 
-const PORT = 3003;
+const PORT = process.env.ENV_PORT || 3003;
 const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
-const redisEndpoints = ['micro-redis.xjdmww.clustercfg.usw1.cache.amazonaws.com:6379']; //remove this from source code
+const redisEndpoints = [process.env.CACHE_ENDPOINT || 'redis://localhost:6379'];
 const corsOptions = {
   origin: true,
   credentials: true,

--- a/src/services/socketServices.ts
+++ b/src/services/socketServices.ts
@@ -3,7 +3,6 @@ import RedisHandler from '../db/redisService.js';
 import { readPreviousMessagesByRoom } from '../db/dynamoService.js';
 import { currentTimeStamp } from "../utils/helpers.js";
 import { parse } from "cookie";
-import { Redis } from "ioredis";
 
 const SHORT_TERM_RECOVERY_TIME_MAX = 120000;
 const LONG_TERM_RECOVERY_TIME_MAX = 86400000;


### PR DESCRIPTION
- `process.env` now working in the cloud 
- Changed lines 14 and 15 in `index.ts` to utilize `process.env` for cache endpoints and Port 