### PR TITLE
Pushing Spencer's cookieFix code

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10,7 +10,7 @@ import CronJobHandler from "./db/redisCronJobs.js";
 import 'dotenv/config';
 import cron from 'node-cron';
 import cors from 'cors';
-const PORT = 3003;
+const PORT = 3004;
 const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
 const redisEndpoints = ['micro-redis.xjdmww.clustercfg.usw1.cache.amazonaws.com:6379']; //remove this from source code
 const corsOptions = {
@@ -41,7 +41,7 @@ export const io = new Server(httpServer, {
         origin: '*',
         methods: ['GET', 'POST'],
         credentials: true,
-    },
+    }
 });
 // Adapter logic
 const subClient = redis.duplicate();
@@ -51,26 +51,16 @@ io.on("connection", handleConnection);
 // Backend API
 app.get('/', homeRoute);
 app.post('/api/twine', publish);
-app.get('/delete-cookie', (_, res) => {
-    res.cookie('twine', '', {
-        httpOnly: true,
-        secure: true,
-        sameSite: 'none',
-        expires: new Date(0) // Set to a past date
-    });
-    res.send('Cookie deleted');
-});
 // Frontend code now sends request to this route before establishing WebSocket connection
 app.get('/set-cookie', (req, res) => {
     const cookies = req.headers.cookie || '';
-    // Parse the cookies
     const cookiesObj = Object.fromEntries(cookies.split(';').map(cookie => {
         const [name, value] = cookie.trim().split('=');
         return [name, value];
     }));
-    if (!cookiesObj.twinert) {
+    if (!cookiesObj.twineid) {
         const sessionID = newUUID();
-        res.cookie('twinert', sessionID, {
+        res.cookie('twineid', sessionID, {
             httpOnly: true,
             secure: true,
             sameSite: 'none',
@@ -79,19 +69,9 @@ app.get('/set-cookie', (req, res) => {
         console.log('First cookie set ', sessionID);
         res.send('First cookie set');
     }
-    else if (!cookiesObj.twinerc) {
-        res.cookie('twinerc', 'y', {
-            httpOnly: true,
-            secure: true,
-            sameSite: 'none',
-            maxAge: TWENTY_FOUR_HOURS
-        });
-        console.log('RC cookie set');
-        res.send('RC cookie set');
-    }
     else {
-        console.log('RC cookie already set');
-        res.send('RC cookie already set');
+        console.log('Cookie already set');
+        res.send('Cookie already set');
     }
 });
 // cron job redis

--- a/src/services/socketServices.ts
+++ b/src/services/socketServices.ts
@@ -3,7 +3,6 @@ import RedisHandler from '../db/redisService.js';
 import { readPreviousMessagesByRoom } from '../db/dynamoService.js';
 import { currentTimeStamp } from "../utils/helpers.js";
 import { parse } from "cookie";
-import { Redis } from "ioredis";
 
 const SHORT_TERM_RECOVERY_TIME_MAX = 120000;
 const LONG_TERM_RECOVERY_TIME_MAX = 86400000;
@@ -101,59 +100,39 @@ const emitMessages = (socket: CustomSocket, messages: messageObject[], room_id: 
 // called when io.on(connect)
 // should always be a twineID and twineTS available at this point, whether reconnect or first time
 export const handleConnection = async (socket: CustomSocket) => {
+  socket.twineID = '';
 
-  socket.on('stateRecovery', async () => {
-    const cookiesData = socket.handshake.headers.cookie as string;
+  if (socket.handshake.headers.cookie) {
+    const cookiesData = socket.handshake.headers.cookie;
     const parsedCookies = parse(cookiesData);
-    let sessionId = parsedCookies.twinert;
-    let sessionRc = parsedCookies.twinerc || false;
+    socket.twineID = parsedCookies.twineid;
+  }
 
-    if (sessionId) {
-      console.log('Twine Session: ', sessionId);
-    } else {
-      console.log('No session found');
+  if (socket.twineID) {
+    console.log('Twine ID: ', socket.twineID);
+  } else {
+    console.log('No Twine ID');
+  }
+
+  socket.twineTS = await RedisHandler.checkSessionTimeStamp(socket.twineID);
+  console.log('Twine TS: ', socket.twineTS);
+
+  if (socket.twineTS) {
+    // re-subscribe to all rooms they were subscribed to before disconnect
+    let subscribedRooms: SubscribedRooms = await RedisHandler.redisSubscribedRooms(socket.twineID)
+    resubscribe(socket, subscribedRooms);
+
+    const timeSinceLastTimestamp = (currentTimeStamp() - socket.twineTS);
+
+    // executes short-term or long-term state recovery based on `timeSinceLastTimestamp`
+    if (timeSinceLastTimestamp <= SHORT_TERM_RECOVERY_TIME_MAX) {
+      console.log('short term state recovery branch executed')
+      emitShortTermReconnectionStateRecovery(socket, socket.twineTS, subscribedRooms);
+    } else if (timeSinceLastTimestamp <= LONG_TERM_RECOVERY_TIME_MAX) {
+      console.log('long term state recovery branch executed')
+      emitLongTermReconnectionStateRecovery(socket, socket.twineTS, subscribedRooms);
     }
-
-    const currDate = new Date();
-    currDate.setHours(currDate.getHours() - 25);
-    const oldDate = currDate.getTime();
-
-    if (sessionRc) {
-      console.log('Reconnect Session');
-    };
-
-    socket.twineID = sessionId || 'a';
-    let redisTS = await RedisHandler.checkSessionTimeStamp(socket.twineID)
-    console.log('AFTER REDIS TS');
-
-    console.log(redisTS);
-    RedisHandler.checkSessionTimeStamp(socket.twineID)
-      .then(data => {
-        redisTS = data;
-      });
-
-    socket.twineTS = redisTS || oldDate;
-
-    console.log(redisTS);
-    // check sessionRc to determine if reconnect
-    console.log(sessionRc);
-    if (sessionRc) {
-      let subscribedRooms: SubscribedRooms = await RedisHandler.redisSubscribedRooms(socket.twineID)
-
-      // re-subscribe to all rooms they were subscribed to before disconnect
-      resubscribe(socket, subscribedRooms);
-      const timeSinceLastTimestamp = (currentTimeStamp() - socket.twineTS);
-
-      // executes short-term or long-term state recovery based on `timeSinceLastTimestamp`
-      if (timeSinceLastTimestamp <= SHORT_TERM_RECOVERY_TIME_MAX) {
-        console.log('short term state recovery branch executed')
-        emitShortTermReconnectionStateRecovery(socket, socket.twineTS, subscribedRooms);
-      } else if (timeSinceLastTimestamp <= LONG_TERM_RECOVERY_TIME_MAX) {
-        console.log('long term state recovery branch executed')
-        emitLongTermReconnectionStateRecovery(socket, socket.twineTS, subscribedRooms);
-      }
-    }
-  });
+  }
 
   socket.on('join', async (roomName) => {
     socket.join(roomName);
@@ -172,5 +151,4 @@ export const handleConnection = async (socket: CustomSocket) => {
     let session = socket.twineID || '';
     RedisHandler.setSessionTime(session);
   });
-
 }


### PR DESCRIPTION
Spencer's notes on these changes:

"My tests show this fixing the cookie/refresh/socket issue.

We need to use await with the fetch to set the cookie before the WS connection. But using await delays the `messages.js` execution enough that the DOM loads first. Then this wouldn’t execute and the client couldn’t join a room:

```
document.addEventListener('DOMContentLoaded', () => {
  const options = document.getElementById('options');

  options.addEventListener('change', () => {
    const selectedOption = options.value;
    // join room <button value> on change event
    // server then emits back to roomJoined (below)
    socket.emit('join', `${selectedOption}`);
  });
});
```
We could check to make sure the DOM has loaded before trying to execute that code, but for our dummy app it shouldn’t matter and it’s probably fine in general to remove the `DOMContentLoaded` wrapper."