### PR TITLE
extracted logic for handling /set-cookie route into its own file

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3,7 +3,8 @@ import { Server } from 'socket.io';
 import express from 'express';
 import { handleConnection } from './services/socketServices.js';
 import { homeRoute, publish } from './services/expressServices.js';
-import { newUUID } from './utils/helpers.js';
+import { setCookie } from './services/cookieServices.js';
+// import { newUUID } from './utils/helpers.js'; // cookie import
 import { Cluster } from "ioredis";
 import { createAdapter } from "@socket.io/redis-adapter";
 import CronJobHandler from "./db/redisCronJobs.js";
@@ -11,7 +12,7 @@ import 'dotenv/config';
 import cron from 'node-cron';
 import cors from 'cors';
 const PORT = process.env.ENV_PORT || 3005;
-const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
+// const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000; // cookie const
 const redisEndpoints = [process.env.CACHE_ENDPOINT || 'redis://localhost:6379'];
 const corsOptions = {
     origin: true,
@@ -52,28 +53,28 @@ io.on("connection", handleConnection);
 app.get('/', homeRoute);
 app.post('/api/twine', publish);
 // Frontend code now sends request to this route before establishing WebSocket connection
-app.get('/set-cookie', (req, res) => {
-    const cookies = req.headers.cookie || '';
-    const cookiesObj = Object.fromEntries(cookies.split(';').map(cookie => {
-        const [name, value] = cookie.trim().split('=');
-        return [name, value];
-    }));
-    if (!cookiesObj.twineid) {
-        const sessionID = newUUID();
-        res.cookie('twineid', sessionID, {
-            httpOnly: true,
-            secure: true,
-            sameSite: 'none',
-            maxAge: TWENTY_FOUR_HOURS
-        });
-        console.log('First cookie set ', sessionID);
-        res.send('First cookie set');
-    }
-    else {
-        console.log('Cookie already set');
-        res.send('Cookie already set');
-    }
-});
+app.get('/set-cookie', setCookie);
+// app.get('/set-cookie', (req, res) => {
+//   const cookies = req.headers.cookie || '';
+//   const cookiesObj = Object.fromEntries(cookies.split(';').map(cookie => {
+//     const [name, value] = cookie.trim().split('=');
+//     return [name, value];
+//   }));
+//   if (!cookiesObj.twineid) {
+//     const sessionID = newUUID();
+//     res.cookie('twineid', sessionID, {
+//       httpOnly: true,
+//       secure: true,
+//       sameSite: 'none',
+//       maxAge: TWENTY_FOUR_HOURS
+//     });
+//     console.log('First cookie set ', sessionID);
+//     res.send('First cookie set');
+//   } else {
+//     console.log('Cookie already set');
+//     res.send('Cookie already set');
+//   }
+// });
 // cron job redis
 const cronSchedule = "*/3 * * * *"; // runs every 3 minutes
 cron.schedule(cronSchedule, CronJobHandler.messageCronJob);

--- a/dist/services/cookieServices.js
+++ b/dist/services/cookieServices.js
@@ -1,0 +1,33 @@
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+import { newUUID } from '../utils/helpers.js';
+const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
+export const setCookie = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const cookies = req.headers.cookie || '';
+    const cookiesObj = Object.fromEntries(cookies.split(';').map(cookie => {
+        const [name, value] = cookie.trim().split('=');
+        return [name, value];
+    }));
+    if (!cookiesObj.twineid) {
+        const sessionID = newUUID();
+        res.cookie('twineid', sessionID, {
+            httpOnly: true,
+            secure: true,
+            sameSite: 'none',
+            maxAge: TWENTY_FOUR_HOURS
+        });
+        console.log('First cookie set ', sessionID);
+        res.send('First cookie set');
+    }
+    else {
+        console.log('Cookie already set');
+        res.send('Cookie already set');
+    }
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ import express from 'express';
 import { handleConnection } from './services/socketServices.js';
 import { homeRoute, publish } from './services/expressServices.js';
 import { setCookie } from './services/cookieServices.js';
-// import { newUUID } from './utils/helpers.js'; // cookie import
 import { Cluster } from "ioredis";
 import { createAdapter } from "@socket.io/redis-adapter";
 import CronJobHandler from "./db/redisCronJobs.js";
@@ -13,7 +12,6 @@ import cron from 'node-cron';
 import cors from 'cors';
 
 const PORT = process.env.ENV_PORT || 3005;
-// const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000; // cookie const
 const redisEndpoints = [process.env.CACHE_ENDPOINT || 'redis://localhost:6379'];
 const corsOptions = {
   origin: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,18 +3,17 @@ import { Server } from 'socket.io';
 import express from 'express';
 import { handleConnection } from './services/socketServices.js';
 import { homeRoute, publish } from './services/expressServices.js';
-import { newUUID } from './utils/helpers.js';
+import { setCookie } from './services/cookieServices.js';
+// import { newUUID } from './utils/helpers.js'; // cookie import
 import { Cluster } from "ioredis";
 import { createAdapter } from "@socket.io/redis-adapter";
 import CronJobHandler from "./db/redisCronJobs.js";
 import 'dotenv/config';
 import cron from 'node-cron';
 import cors from 'cors';
-import { serialize } from "cookie";
-
 
 const PORT = process.env.ENV_PORT || 3005;
-const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
+// const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000; // cookie const
 const redisEndpoints = [process.env.CACHE_ENDPOINT || 'redis://localhost:6379'];
 const corsOptions = {
   origin: true,
@@ -66,10 +65,7 @@ interface InterServerEvents {
 };
 
 interface SocketData {
-  name: string;
-  age: number;
   sessionId: string;
-  offset: Date;
 };
 
 interface SessionObject {
@@ -102,31 +98,32 @@ app.get('/', homeRoute);
 app.post('/api/twine', publish);
 
 // Frontend code now sends request to this route before establishing WebSocket connection
-app.get('/set-cookie', (req, res) => {
-  const cookies = req.headers.cookie || '';
+app.get('/set-cookie', setCookie);
+// app.get('/set-cookie', (req, res) => {
+//   const cookies = req.headers.cookie || '';
 
-  const cookiesObj = Object.fromEntries(cookies.split(';').map(cookie => {
-    const [name, value] = cookie.trim().split('=');
-    return [name, value];
-  }));
+//   const cookiesObj = Object.fromEntries(cookies.split(';').map(cookie => {
+//     const [name, value] = cookie.trim().split('=');
+//     return [name, value];
+//   }));
 
-  if (!cookiesObj.twineid) {
-    const sessionID = newUUID();
+//   if (!cookiesObj.twineid) {
+//     const sessionID = newUUID();
 
-    res.cookie('twineid', sessionID, {
-      httpOnly: true,
-      secure: true,
-      sameSite: 'none',
-      maxAge: TWENTY_FOUR_HOURS
-    });
+//     res.cookie('twineid', sessionID, {
+//       httpOnly: true,
+//       secure: true,
+//       sameSite: 'none',
+//       maxAge: TWENTY_FOUR_HOURS
+//     });
 
-    console.log('First cookie set ', sessionID);
-    res.send('First cookie set');
-  } else {
-    console.log('Cookie already set');
-    res.send('Cookie already set');
-  }
-});
+//     console.log('First cookie set ', sessionID);
+//     res.send('First cookie set');
+//   } else {
+//     console.log('Cookie already set');
+//     res.send('Cookie already set');
+//   }
+// });
 
 // cron job redis
 const cronSchedule = "*/3 * * * *"; // runs every 3 minutes

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,31 +99,7 @@ app.post('/api/twine', publish);
 
 // Frontend code now sends request to this route before establishing WebSocket connection
 app.get('/set-cookie', setCookie);
-// app.get('/set-cookie', (req, res) => {
-//   const cookies = req.headers.cookie || '';
 
-//   const cookiesObj = Object.fromEntries(cookies.split(';').map(cookie => {
-//     const [name, value] = cookie.trim().split('=');
-//     return [name, value];
-//   }));
-
-//   if (!cookiesObj.twineid) {
-//     const sessionID = newUUID();
-
-//     res.cookie('twineid', sessionID, {
-//       httpOnly: true,
-//       secure: true,
-//       sameSite: 'none',
-//       maxAge: TWENTY_FOUR_HOURS
-//     });
-
-//     console.log('First cookie set ', sessionID);
-//     res.send('First cookie set');
-//   } else {
-//     console.log('Cookie already set');
-//     res.send('Cookie already set');
-//   }
-// });
 
 // cron job redis
 const cronSchedule = "*/3 * * * *"; // runs every 3 minutes

--- a/src/services/cookieServices.ts
+++ b/src/services/cookieServices.ts
@@ -1,0 +1,29 @@
+import { Request, Response } from "express";
+import { newUUID } from '../utils/helpers.js';
+const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
+
+export const setCookie = async (req: Request, res: Response) => {
+  const cookies = req.headers.cookie || '';
+
+  const cookiesObj = Object.fromEntries(cookies.split(';').map(cookie => {
+    const [name, value] = cookie.trim().split('=');
+    return [name, value];
+  }));
+
+  if (!cookiesObj.twineid) {
+    const sessionID = newUUID();
+
+    res.cookie('twineid', sessionID, {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'none',
+      maxAge: TWENTY_FOUR_HOURS
+    });
+
+    console.log('First cookie set ', sessionID);
+    res.send('First cookie set');
+  } else {
+    console.log('Cookie already set');
+    res.send('Cookie already set');
+  }
+};


### PR DESCRIPTION
Updated `index.ts` file
- Extracted `/set-cookie` route logic - and any relevant imports/variables* - into it's own file; `services/cookieServices.ts`

*`newUUID` import and the constant `TWENTY_FOUR_HOURS` were moved into the new file too.