### PR TITLE
Classifying dynamo services

### DIFF
--- a/src/db/dynamoService.ts
+++ b/src/db/dynamoService.ts
@@ -15,13 +15,11 @@ const clientConfig: DynamoDBClientConfig = { credentials: fromEnv() };
 const client = new DynamoDBClient(clientConfig);
 const docClient = DynamoDBDocumentClient.from(client);
 const TableName = 'rooms';
-// const KeyConditionExpression = '#id = :id AND #time_created > :last_timestamp';
 
 class DynamoHandler {  
   public static async createMessage(room_id: string, message: string) {
     const time_created = currentTimeStamp();
     const command = new PutCommand({
-      // TableName: "rooms",
       TableName,
       Item: {
         id: room_id,
@@ -56,7 +54,6 @@ class DynamoHandler {
     while (totalItems < MAX_RETURN) {
       const params: any = {
         TableName,
-        // KeyConditionExpression,
         KeyConditionExpression: '#id = :id AND #time_created > :last_timestamp',
         ExpressionAttributeNames: {
           "#id": "id",

--- a/src/db/dynamoService.ts
+++ b/src/db/dynamoService.ts
@@ -15,81 +15,87 @@ const clientConfig: DynamoDBClientConfig = { credentials: fromEnv() };
 const client = new DynamoDBClient(clientConfig);
 const docClient = DynamoDBDocumentClient.from(client);
 const TableName = 'rooms';
-const KeyConditionExpression = '#id = :id AND #time_created > :last_timestamp';
-const LimitPerQuery = 100; // Adjust this value based on your needs
+// const KeyConditionExpression = '#id = :id AND #time_created > :last_timestamp';
 
-export const createMessage = async (room_id: string, message: string) => {
-  const time_created = currentTimeStamp();
-  const command = new PutCommand({
-    TableName: "rooms",
-    Item: {
-      id: room_id,
-      time_created,
-      payload: message
-    },
-  });
-
-  try {
-    const response = await docClient.send(command);
-
-    return {
-      status_code: response['$metadata']['httpStatusCode'],
-      room_id,
-      time_created,
-      payload: {
-        message
-      }
-    }
-  } catch (error) {
-    return error;
-  }
-};
-
-export const readPreviousMessagesByRoom = async (room_id: string, last_timestamp: number) => {
-  let lastEvaluatedKey = undefined;
-  let responseItems: any[] = [];
-  let totalItems: number = 0;
-  const MAX_RETURN: number = 1000;
-
-  while (totalItems < MAX_RETURN) {
-    const params: any = {
+class DynamoHandler {  
+  public static async createMessage(room_id: string, message: string) {
+    const time_created = currentTimeStamp();
+    const command = new PutCommand({
+      // TableName: "rooms",
       TableName,
-      KeyConditionExpression,
-      ExpressionAttributeNames: {
-        "#id": "id",
-        '#time_created': 'time_created'
+      Item: {
+        id: room_id,
+        time_created,
+        payload: message
       },
-      ExpressionAttributeValues: {
-        ":id": { S: room_id },
-        ":last_timestamp": { N: last_timestamp.toString() }
-      },
-      Limit: LimitPerQuery,
-      ExclusiveStartKey: lastEvaluatedKey,
-    };
-
-    const command = new QueryCommand(params);
-
+    });
+    
     try {
-      const { Items, LastEvaluatedKey } = await client.send(command);
-      if (Items) {
-        totalItems += Items.length;
-        (Items || []).forEach((item) => {
-          responseItems.push(unmarshall(item));
-        });
-      }
-      if (totalItems >= MAX_RETURN || !LastEvaluatedKey) {
-        break;
-      }
-      if (LastEvaluatedKey) {
-        lastEvaluatedKey = LastEvaluatedKey;
+      const response = await docClient.send(command);
+      
+      return {
+        status_code: response['$metadata']['httpStatusCode'],
+        room_id,
+        time_created,
+        payload: {
+          message
+        }
       }
     } catch (error) {
-      console.log('Error querying DynamoDB:', error);
       return error;
     }
-  }
-
-  return responseItems.length > MAX_RETURN
+  };
+  
+  public static async readPreviousMessagesByRoom(room_id: string, last_timestamp: number) {
+    let lastEvaluatedKey = undefined;
+    let responseItems: any[] = [];
+    let totalItems: number = 0;
+    const LimitPerQuery = 100;
+    const MAX_RETURN: number = 1000;
+    
+    while (totalItems < MAX_RETURN) {
+      const params: any = {
+        TableName,
+        // KeyConditionExpression,
+        KeyConditionExpression: '#id = :id AND #time_created > :last_timestamp',
+        ExpressionAttributeNames: {
+          "#id": "id",
+          '#time_created': 'time_created'
+        },
+        ExpressionAttributeValues: {
+          ":id": { S: room_id },
+          ":last_timestamp": { N: last_timestamp.toString() }
+        },
+        Limit: LimitPerQuery,
+        ExclusiveStartKey: lastEvaluatedKey,
+      };
+      
+      const command = new QueryCommand(params);
+      
+      try {
+        const { Items, LastEvaluatedKey } = await client.send(command);
+        if (Items) {
+          totalItems += Items.length;
+          (Items || []).forEach((item) => {
+            responseItems.push(unmarshall(item));
+          });
+        }
+        if (totalItems >= MAX_RETURN || !LastEvaluatedKey) {
+          break;
+        }
+        if (LastEvaluatedKey) {
+          lastEvaluatedKey = LastEvaluatedKey;
+        }
+      } catch (error) {
+        console.log('Error querying DynamoDB:', error);
+        return error;
+      }
+    }
+    
+    return responseItems.length > MAX_RETURN
     ? responseItems.slice(-MAX_RETURN)
     : responseItems;
-};
+  };
+}
+  
+export default DynamoHandler;

--- a/src/services/expressServices.ts
+++ b/src/services/expressServices.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { io } from '../index.js';
-import { createMessage } from "../db/dynamoService.js";
 import RedisHandler from '../db/redisService.js';
+import DynamoHandler from "../db/dynamoService.js";
 import { currentTimeStamp } from '../utils/helpers.js';
 
 interface messageObject {
@@ -15,13 +15,6 @@ interface jsonData {
   payload: messageObject;
 };
 
-// type DynamoCreateResponse = {
-//   status_code: number | undefined,
-//   room_id: string,
-//   time_created: number,
-//   payload: object
-// };
-
 export const homeRoute = (_: Request, res: Response) => {
   console.log("you've got mail!");
   res.send('Nice work');
@@ -29,10 +22,10 @@ export const homeRoute = (_: Request, res: Response) => {
 
 const publishToDynamo = async (room_id: string, payload: object) => {
   try {
-    const dynamoResponse: any = await createMessage(
+    const dynamoResponse: any = await DynamoHandler.createMessage(
       room_id,
       JSON.stringify(payload)
-    ) //as DynamoCreateResponse;
+    )
 
     if (!dynamoResponse.status_code) {
       throw Error('An error occured while trying to publish your message.');

--- a/src/services/socketServices.ts
+++ b/src/services/socketServices.ts
@@ -1,6 +1,6 @@
 import { Socket } from "socket.io";
 import RedisHandler from '../db/redisService.js';
-import { readPreviousMessagesByRoom } from '../db/dynamoService.js';
+import DynamoHandler from "../db/dynamoService.js";
 import { currentTimeStamp } from "../utils/helpers.js";
 import { parse } from "cookie";
 
@@ -76,10 +76,10 @@ const emitLongTermReconnectionStateRecovery = async (socket: CustomSocket, times
     console.log('room', room)
     if (timestamp > joinTime) {
       console.log('twineTS is greater')
-      messages = await readPreviousMessagesByRoom(room, timestamp + 1) as DynamoMessage[];
+      messages = await DynamoHandler.readPreviousMessagesByRoom(room, timestamp + 1) as DynamoMessage[];
     } else {
       console.log('joinTime is greater')
-      messages = await readPreviousMessagesByRoom(room, joinTime + 1) as DynamoMessage[];
+      messages = await DynamoHandler.readPreviousMessagesByRoom(room, joinTime + 1) as DynamoMessage[];
     }
     console.log('retrieved long-term messages', messages)
     let parsedMessages = parseDynamoMessages(messages);


### PR DESCRIPTION
Updated the following 3 files:
`dynamoServices.ts` to wrap functions `#createMessage` and `#readPreviousMessagesByRoom` in class `DynamoHandler`. Mirroring the `redisServices` file, both functions are public static async functions. I also updated local variables as needed, e.g. there was a top level variable only being used in one of the two functions, so I moved it within the relevant function.

`expressServices` to import `DynamoHandler` and call `#createMessage` appropriately (i.e. directly on the class)

`socketServices` to import `DynamoHandler` and call `#readPreviousMessagesByRoom` appropriately (i.e. directly on the class)<br><br>

Messages are being saved error-free to DynamoDB and both short & long-term state recovery are still working as expected.
